### PR TITLE
Make duration configurable

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -7,4 +7,5 @@ duration="$(snapctl get duration)"
 if ! expr "$duration" : '^[0-9]*$' > /dev/null; then
     echo "\"$duration\" is not a valid duration, reveting to $DEFAULT_DURATION seconds" >&2
     snapctl set duration="$DEFAULT_DURATION"
+    snapctl restart "$SNAP_NAME".imv
 fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,11 @@
+#!/bin/sh -e
+
+DEFAULT_DURATION=10
+
+duration="$(snapctl get duration)"
+
+if ! expr "$duration" : '^[0-9]*$' > /dev/null; then
+    echo "\"$duration\" is not a valid duration, reveting to $DEFAULT_DURATION seconds" >&2
+    duration="$DEFAULT_DURATION"
+    snapctl set duration="$duration"
+fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -6,6 +6,5 @@ duration="$(snapctl get duration)"
 
 if ! expr "$duration" : '^[0-9]*$' > /dev/null; then
     echo "\"$duration\" is not a valid duration, reveting to $DEFAULT_DURATION seconds" >&2
-    duration="$DEFAULT_DURATION"
-    snapctl set duration="$duration"
+    snapctl set duration="$DEFAULT_DURATION"
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -94,8 +94,6 @@ parts:
       - libopenjp2-7
       - libraw16
       - libwebpmux3
-    organize:
-      imv.wrapper: bin/imv.wrapper
   filebrowser:
     source: https://github.com/serverwentdown/file-manager.git
     source-depth: 1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,9 +5,11 @@ description: |
   Image viewer for mir-kiosk based on imv
 
   Put Pictures into /var/snap/picviewer-kiosk/common/,
-  restart the snap with "snap restart picviewer-kiosk" and the
-  Pictures will run as a slideshow at a 10 second rotation 
-  frequency.
+  restart the snap with "snap restart picviewer-kiosk".
+
+  Pictures will run as a slideshow. The time per picture can be
+  changed via "snap set picviewer-kiosk duration=30", the default
+  is 10 seconds per image.
 
   Support for over 30 different image file formats including
     - Photoshop PSD files
@@ -27,7 +29,7 @@ confinement: strict
 
 apps:
   picviewer-kiosk:
-    command: snap/command-chain/desktop-launch $SNAP/usr/bin/imv -b checks -f -t 10 $SNAP_COMMON/
+    command: snap/command-chain/desktop-launch $SNAP/bin/imv.wrapper
     daemon: simple
     restart-condition: always
     extensions: [ gnome-3-28 ]
@@ -69,3 +71,11 @@ parts:
       - libopenjp2-7
       - libraw16
       - libwebpmux3
+    organize:
+      imv.wrapper: bin/imv.wrapper
+
+  wrappers:
+    source: wrappers/
+    plugin: dump
+    organize:
+      imv.wrapper: bin/imv.wrapper

--- a/wrappers/imv.wrapper
+++ b/wrappers/imv.wrapper
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+DURATION="$(snapctl get duration)"
+exec "$SNAP/usr/bin/imv" -f -t "$DURATION" "$SNAP_COMMON/"


### PR DESCRIPTION
This adds the possibility to configure the time an image is shown, defaulting to 10 seconds per image.

The user of the snap can set their own duration via `snap set picviewer-kiosk duration=60` (for a one minute per picture slideshow) which will be passed on to imv's `-t 60` flag via the wrapper script. The configure script will default to 10 seconds if the provided value is invalid.

It's the first time I try to add a configuration option to a snap so maybe someone with more experience can point out my mistakes.