### PR TITLE
Remove unnecessary X11 dependency

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -86,7 +86,6 @@ parts:
       - libglu1-mesa-dev
       - libcmocka-dev
       - librsvg2-dev
-      - libxkbcommon-x11-dev
       - libwayland-dev
       - xsltproc
     stage-packages:


### PR DESCRIPTION
Since the snap requires mir-kiosk to run we know we don't need X11 support: imv is built for Wayland only. If I am not mistaken libxkbcommon-x11-dev is an X11 dependency that has been added in the past but is no longer needed.

I tried a clean build without libxkbcommon-x11-dev and everything still seems to work fine.

This is a restored pull request of #2 which was closed by mistake.